### PR TITLE
APIサーバーのURLをIPではなくドメインに

### DIFF
--- a/aws/bin/aws.ts
+++ b/aws/bin/aws.ts
@@ -1,8 +1,16 @@
 #!/usr/bin/env node
 import * as cdk from 'aws-cdk-lib';
 import { LivaisDevStack } from '../lib/livais-dev-stack';
+import dotenv from 'dotenv';
+import path from "node:path";
+
+dotenv.config({ path: path.resolve(__dirname, '../../.env') })
 
 const app = new cdk.App();
 new LivaisDevStack(app, 'LivaisDevStack', {
     description: 'Stack for Developing Livais',
+    env: {
+        account: process.env.CDK_DEFAULT_ACCOUNT,
+        region: process.env.CDK_DEFAULT_REGION,
+    },
 });

--- a/aws/cdk.context.json
+++ b/aws/cdk.context.json
@@ -1,0 +1,11 @@
+{
+  "availability-zones:account=818292098712:region=ap-northeast-1": [
+    "ap-northeast-1a",
+    "ap-northeast-1c",
+    "ap-northeast-1d"
+  ],
+  "hosted-zone:account=818292098712:domainName=livais-api.com:region=ap-northeast-1": {
+    "Id": "/hostedzone/Z07299513ARQVSMEIH8D9",
+    "Name": "livais-api.com."
+  }
+}

--- a/aws/lib/livais-dev-stack.ts
+++ b/aws/lib/livais-dev-stack.ts
@@ -74,8 +74,8 @@ export class LivaisDevStack extends cdk.Stack {
             instanceName: serverName
         })
 
-        const setupScript = readFileSync('./lib/resources/setup-dev.sh', 'utf-8')
-        devServer.addUserData(setupScript)
+        // const setupScript = readFileSync('./lib/resources/setup-dev.sh', 'utf-8')
+        // devServer.addUserData(setupScript)
 
         // ElasticIPをEC2に設定
         new ec2.CfnEIP(this, 'DevServerElasticIp', {

--- a/aws/lib/livais-dev-stack.ts
+++ b/aws/lib/livais-dev-stack.ts
@@ -17,7 +17,7 @@ export class LivaisDevStack extends cdk.Stack {
 
         // AvailabilityZone
         const appRegion = 'ap-northeast-1'
-        const availabilityZoneNames = ['ap-northeast-1a', 'ap-northeast-1c']
+        const availabilityZoneNames = [`${appRegion}a`, `${appRegion}c`]
 
         // VPC
         // publicSubnet, privateSubnetを各AZに1つずつ作成

--- a/aws/lib/livais-dev-stack.ts
+++ b/aws/lib/livais-dev-stack.ts
@@ -17,7 +17,7 @@ export class LivaisDevStack extends cdk.Stack {
 
         // AvailabilityZone
         const appRegion = 'ap-northeast-1'
-        const availabilityZoneNames = [`${appRegion}a`, `${appRegion}c`]
+        const availabilityZoneNames = [`${ appRegion }a`, `${ appRegion }c`]
 
         // VPC
         // publicSubnet, privateSubnetを各AZに1つずつ作成
@@ -91,7 +91,6 @@ export class LivaisDevStack extends cdk.Stack {
             target: RecordTarget.fromIpAddresses(devServerEip.ref),
             zone: hostZone,
             recordName: "dev",
-            region: appRegion,
         })
 
         // RDS

--- a/aws/lib/livais-dev-stack.ts
+++ b/aws/lib/livais-dev-stack.ts
@@ -84,7 +84,7 @@ export class LivaisDevStack extends cdk.Stack {
 
         // Route53
         const hostZone = HostedZone.fromLookup(this, 'DevServerZone', {
-            domainName: 'livais-api.com'
+            domainName: process.env.DOMAIN_NAME as string,
         })
 
         new ARecord(this, "DevServerARecord", {

--- a/aws/lib/livais-dev-stack.ts
+++ b/aws/lib/livais-dev-stack.ts
@@ -78,7 +78,7 @@ export class LivaisDevStack extends cdk.Stack {
         // devServer.addUserData(setupScript)
 
         // ElasticIPをEC2に設定
-        new ec2.CfnEIP(this, 'DevServerElasticIp', {
+        const devServerEip = new ec2.CfnEIP(this, 'DevServerElasticIp', {
             instanceId: devServer.instanceId,
         })
 
@@ -88,7 +88,7 @@ export class LivaisDevStack extends cdk.Stack {
         })
 
         new ARecord(this, "DevServerARecord", {
-            target: RecordTarget.fromIpAddresses(process.env.DEV_EC2_IP as string),
+            target: RecordTarget.fromIpAddresses(devServerEip.ref),
             zone: hostZone,
             recordName: "dev",
             region: appRegion,

--- a/aws/lib/livais-dev-stack.ts
+++ b/aws/lib/livais-dev-stack.ts
@@ -4,16 +4,13 @@ import { Construct } from 'constructs';
 import * as ec2 from 'aws-cdk-lib/aws-ec2';
 import * as rds from 'aws-cdk-lib/aws-rds';
 import { KeyPair } from "cdk-ec2-key-pair";
-import dotenv from 'dotenv';
 import * as path from "node:path";
-import { readFileSync } from "fs";
 import { ARecord, HostedZone, RecordTarget } from "aws-cdk-lib/aws-route53";
 
 
 export class LivaisDevStack extends cdk.Stack {
     constructor(scope: Construct, id: string, props?: cdk.StackProps) {
         super(scope, id, props)
-        dotenv.config({ path: path.resolve(__dirname, '../../.env') })
 
         // AvailabilityZone
         const appRegion = 'ap-northeast-1'

--- a/aws/lib/livais-dev-stack.ts
+++ b/aws/lib/livais-dev-stack.ts
@@ -14,7 +14,7 @@ export class LivaisDevStack extends cdk.Stack {
 
         // AvailabilityZone
         const appRegion = 'ap-northeast-1'
-        const availabilityZoneNames = [`${ appRegion }a`, `${ appRegion }c`]
+        const availabilityZoneNames = [`${appRegion}a`, `${appRegion}c`]
 
         // VPC
         // publicSubnet, privateSubnetを各AZに1つずつ作成
@@ -88,6 +88,7 @@ export class LivaisDevStack extends cdk.Stack {
             target: RecordTarget.fromIpAddresses(devServerEip.ref),
             zone: hostZone,
             recordName: "dev",
+            region: appRegion,
         })
 
         // RDS

--- a/aws/lib/livais-dev-stack.ts
+++ b/aws/lib/livais-dev-stack.ts
@@ -90,7 +90,7 @@ export class LivaisDevStack extends cdk.Stack {
         new ARecord(this, "DevServerARecord", {
             target: RecordTarget.fromIpAddresses(process.env.DEV_EC2_IP as string),
             zone: hostZone,
-            recordName: "DevServerRecord",
+            recordName: "dev",
             region: appRegion,
         })
 

--- a/aws/lib/livais-dev-stack.ts
+++ b/aws/lib/livais-dev-stack.ts
@@ -7,6 +7,7 @@ import { KeyPair } from "cdk-ec2-key-pair";
 import dotenv from 'dotenv';
 import * as path from "node:path";
 import { readFileSync } from "fs";
+import { ARecord, HostedZone, RecordTarget } from "aws-cdk-lib/aws-route53";
 
 
 export class LivaisDevStack extends cdk.Stack {
@@ -15,6 +16,7 @@ export class LivaisDevStack extends cdk.Stack {
         dotenv.config({ path: path.resolve(__dirname, '../../.env') })
 
         // AvailabilityZone
+        const appRegion = 'ap-northeast-1'
         const availabilityZoneNames = ['ap-northeast-1a', 'ap-northeast-1c']
 
         // VPC
@@ -78,6 +80,18 @@ export class LivaisDevStack extends cdk.Stack {
         // ElasticIPをEC2に設定
         new ec2.CfnEIP(this, 'DevServerElasticIp', {
             instanceId: devServer.instanceId,
+        })
+
+        // Route53
+        const hostZone = HostedZone.fromLookup(this, 'DevServerZone', {
+            domainName: 'livais-api.com'
+        })
+
+        new ARecord(this, "DevServerARecord", {
+            target: RecordTarget.fromIpAddresses(process.env.DEV_EC2_IP as string),
+            zone: hostZone,
+            recordName: "DevServerRecord",
+            region: appRegion,
         })
 
         // RDS

--- a/aws/lib/resources/setup-dev-manually.sh
+++ b/aws/lib/resources/setup-dev-manually.sh
@@ -77,7 +77,9 @@ RAILS_ENV=production rails s -b 0.0.0.0 -p 3000  # 実行して確認
 
 # setup daemon service
 sudo mkdir -p /etc/systemd/system/
+cd /etc/systemd/system
 sudo touch livais-api.service
+sudo vim livais-api.service # paste livais-api.service
 sudo systemctl daemon-reload
 sudo systemctl enable livais-api
 sudo systemctl start livais-api


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
- [ ] セルフレビューをしたらチェックを入れてください
- [ ] github copilot以外のAIレビューをしたらチェックを入れてください
- [ ] github copilot reviewを依頼し、解決した

## 関連 issue
Resolve #221 
<!-- resolve #<issue-number> -->

## やったこと
Route53によりドメイン「livais-api」を取得し、ec2に紐づけてドメインでアクセスできるようにした

### 概要

<!-- 変更内容を 1 行程度でまとめまとめてください。 (チケットタイトルと被っても OK) --> 

### 詳細

<!-- 変更内容をリスト形式でまとめてください。 -->

### 影響範囲

<!-- DB や API エンドポイントの変更など、大きな影響がある場合はその旨をここに書いてください。 -->

## 備考

<!-- この PR についての課題や、議論したいことがあればここに書いてください。 -->

<!-- for GitHub Copilot review rule -->
<!--
レビューする際には、以下のprefix(接頭辞)をつけてください
[must]  
[imo] (in my opinion)  
[nits](nitpick) 
[ask]  
[fyi]
-->
<!-- for GitHub Copilot review  rule-->

<!-- I want to review in Japanese. -->